### PR TITLE
Telecomm: Squashed phone_type switch support

### DIFF
--- a/src/com/android/server/telecom/CallsManager.java
+++ b/src/com/android/server/telecom/CallsManager.java
@@ -419,7 +419,8 @@ public class CallsManager extends Call.ListenerBase
                 (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE), mLock);
         mCallAudioManager = new CallAudioManager(callAudioRouteStateMachine,
                 this,new CallAudioModeStateMachine((AudioManager)
-                        mContext.getSystemService(Context.AUDIO_SERVICE)),
+                        mContext.getSystemService(Context.AUDIO_SERVICE),
+                        (TelecomManager) mContext.getSystemService(Context.TELECOM_SERVICE)),
                 playerFactory, mRinger, new RingbackPlayer(playerFactory),
                 bluetoothStateReceiver, mDtmfLocalTonePlayer);
 

--- a/tests/src/com/android/server/telecom/tests/CallAudioModeStateMachineTest.java
+++ b/tests/src/com/android/server/telecom/tests/CallAudioModeStateMachineTest.java
@@ -17,6 +17,7 @@
 package com.android.server.telecom.tests;
 
 import android.media.AudioManager;
+import android.telecom.TelecomManager;
 import android.test.suitebuilder.annotation.SmallTest;
 
 import com.android.server.telecom.CallAudioManager;
@@ -42,6 +43,7 @@ public class CallAudioModeStateMachineTest extends TelecomTestCase {
 
     @Mock private AudioManager mAudioManager;
     @Mock private CallAudioManager mCallAudioManager;
+    @Mock private TelecomManager mTelecomManager;
 
     @Override
     @Before
@@ -52,7 +54,7 @@ public class CallAudioModeStateMachineTest extends TelecomTestCase {
     @SmallTest
     @Test
     public void testNoFocusWhenRingerSilenced() throws Throwable {
-        CallAudioModeStateMachine sm = new CallAudioModeStateMachine(mAudioManager);
+        CallAudioModeStateMachine sm = new CallAudioModeStateMachine(mAudioManager, mTelecomManager);
         sm.setCallAudioManager(mCallAudioManager);
         sm.sendMessage(CallAudioModeStateMachine.ABANDON_FOCUS_FOR_TESTING);
         waitForHandlerAction(sm.getHandler(), TEST_TIMEOUT);
@@ -84,7 +86,7 @@ public class CallAudioModeStateMachineTest extends TelecomTestCase {
     @SmallTest
     @Test
     public void testRegainFocusWhenHfpIsConnectedSilenced() throws Throwable {
-        CallAudioModeStateMachine sm = new CallAudioModeStateMachine(mAudioManager);
+        CallAudioModeStateMachine sm = new CallAudioModeStateMachine(mAudioManager, mTelecomManager);
         sm.setCallAudioManager(mCallAudioManager);
         sm.sendMessage(CallAudioModeStateMachine.ABANDON_FOCUS_FOR_TESTING);
         waitForHandlerAction(sm.getHandler(), TEST_TIMEOUT);


### PR DESCRIPTION
 * This is still required for some legacy MSIM devices and instructs
   the audio HAL's MSIM voice extension which VOICE_CALL usecase should
   be used when placing phone calls.

 * Current change is based on the following commits, with some slight
   simplifications and the necessary changes to adapt to the new code.

   Author: ljzyal <ljzyal@gmail.com>
   Date:   Mon Jul 20 17:02:50 2015 +0800

       Telecomm: Support Samsung Dual Sims Phone phone_type switch

       Change-Id: Id6a91a47a5d9ebbb39869a66c05eeec14e1366e2

   Author: Bruno Martins <bgcngm@gmail.com>
   Date: 2015-08-06 23:26:41 +0100

       Telecomm: Make phone_type switch generic

       Change-Id: I78129aaab82493c1107699932f7ae8d780006c8f

   Author: Bruno Martins <bgcngm@gmail.com>
   Date: 2015-08-20 19:38:07 +0100

       Telecomm: Avoid NPE when invoking setAudioParameters

        * This exception would occur when preferred SIM for calls was set to
          "Ask every time" and if dialog was dismissed before starting the call

       Change-Id: Iee9968a7ad95fa16a085ecd7e765873904e0b88a

   Author: hawst1 <hawst1@gmail.com>
   Date: 2015-11-02 22:39:58 +0700

       - Fix SIP soft-reboot on call

       Change-Id: Ic78c52bbbe6b93b78bfdb8fdef479ef93ce1bd9f

   Author: Gabriele M <moto.falcon.git@gmail.com>
   Date:   Tue Jan 3 21:29:12 2017 +0100

       Telecomm: Set MSIM audio params using the proper ID

       It is assumed that the ID of every PhoneAccountHandle is the string
       equivalent of an int, however, the ID can also includes hex chars or,
       in case of the emergency account handle, it's just "E". This causes
       issues when we try to get the sub ID using Integer.parseInt(),
       so don't do it.

       Change-Id: Iae6cfacaf65bb2791b6fa9ae491bb4ad6edbe936

   Author: Simon Shields <keepcalm444@gmail.com>
   Date:   Fri Jan 27 22:12:40 2017 +1100

       CallAudioModeStateMachineTest: fix compilation

       Change-Id: Ie58189ce192469762aedfede18db7ce417d86f5d

   Author: Bruno Martins <bgcngm@gmail.com>
   Date:   Sun May 6 02:11:09 2018 +0100

       Telecomm: Account for default data sub ID when setting MSIM audio params

        * After all, the preferred SIM for mobile data also determines if
          audio routing must be switched. In case SIM2 is set to the
          preferred one, then the whole logic needs to be inverted.

        * This also addresses the edge case where in-call audio was broken
          while calling from SIM2 without any SIM card inserted in slot 0.
          Quite obviously, since default data SIM is automatically set to
          match the one and only inserted SIM card.

       Change-Id: I72be3cf30d23b5993e5e54a48e377c8ad976d860

Change-Id: Ie0af8e7d1b65960b0d020cb90dd409fe04c1c512
Signed-off-by: Mrinal Ghosh <mg712702@gmail.com>